### PR TITLE
fix: return on undefined stylesheets

### DIFF
--- a/src/withGlobals.ts
+++ b/src/withGlobals.ts
@@ -37,6 +37,10 @@ function injectStylesheet(stylesheet: string) {
   const bodyElement = document.querySelector('body');
   const stylesheetElement = document.createElement('link');
 
+  if (!stylesheet) {
+    return
+  }
+
   stylesheetElement.setAttribute('id', 'stylesheetToggle');
   stylesheetElement.setAttribute('rel', 'stylesheet');
   stylesheetElement.setAttribute('href', stylesheet);


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.9--canary.8.521e682.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @stevendejong/storybook-stylesheet-toggle@0.0.9--canary.8.521e682.0
  # or 
  yarn add @stevendejong/storybook-stylesheet-toggle@0.0.9--canary.8.521e682.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
